### PR TITLE
Additional firefox preferences

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -34,6 +34,7 @@ The following environment variables can be set to configure your tests:
   REMOTE_BROWSER_VERSION - used when specifying remote test on a grid the provides a choice of browser versions for a given browser
   REMOTE_URL - URL of remote Selenium-Webdriver server e.g. http://yourremotehost:4444/wd/hub
   FIREFOX_PROFILE - specify a firefox profile to use when running in-browser tests (local or remote)
+  FIREFOX_PREFS - specify a json string of additional preferences e.g. FIREFOX_PREFS='{"javascript.enabled": false}'
   CELERITY_JS_ENABLED (string - 'true', 'false') - determines whether Celerity (HTMLUnit) attempts to execute javascript 
   XVFB - (string - 'true', 'false') - determines whether XVFB is used to run browser (i.e. headless Firefox on *nix platform)
   FW_CERT_LOCATION - path to client certificate (combined pem)

--- a/frameworks-capyabara.gemspec
+++ b/frameworks-capyabara.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency("capybara", [">=1.0.0"])
   s.add_runtime_dependency("capybara-mechanize", [">=0.3.0"])
   s.add_runtime_dependency("capybara-celerity")
+  s.add_runtime_dependency("json")
   s.add_runtime_dependency("w3c_validators")
   s.add_development_dependency("cucumber", [">= 0.10.5"])
   s.add_development_dependency("rake")

--- a/lib/frameworks/capybara.rb
+++ b/lib/frameworks/capybara.rb
@@ -64,8 +64,11 @@ class CapybaraSetup
   def register_selenium_driver(opts,remote_opts,custom_opts)
     Capybara.register_driver :selenium do |app|
 
-      opts[:profile] = create_profile(opts[:profile]) if(opts[:profile])
-      opts[:switches] = [opts.delete(:chrome_switches)] if(opts[:chrome_switches])
+      if opts[:profile] or opts[:browser] == :firefox or remote_opts[:browser_name] == :firefox
+        opts[:profile] = create_profile(opts[:profile])
+      elsif opts[:chrome_switches]
+        opts[:switches] = [opts.delete(:chrome_switches)]
+      end
 
       if opts[:browser] == :remote
         client = Selenium::WebDriver::Remote::Http::Default.new
@@ -104,15 +107,15 @@ class CapybaraSetup
       profile["network.proxy.ssl"] = @proxy_host 
       profile["network.proxy.http_port"] = 80
       profile["network.proxy.ssl_port"] = 80
-      profile.native_events = true
     elsif(profile_name == 'DISABLED_REFERER')
       profile = Selenium::WebDriver::Firefox::Profile.new
       profile["network.http.sendRefererHeader"] = 0
-      profile.native_events = true
-    else
+    elsif(profile_name)
       profile = Selenium::WebDriver::Firefox::Profile.from_name profile_name
-      profile.native_events = true
+    else
+      profile = Selenium::WebDriver::Firefox::Profile.new
     end
+    profile.native_events = true
     profile
   end
 

--- a/spec/frameworks_capybara_spec.rb
+++ b/spec/frameworks_capybara_spec.rb
@@ -28,6 +28,7 @@ shared_examples_for "Selenium Driver Options Array" do
     Capybara.current_session.driver.options[:job_name].should == nil
     Capybara.current_session.driver.options[:chrome_switches].should == nil
     Capybara.current_session.driver.options[:max_duration].should == nil
+    Capybara.current_session.driver.options[:firefox_prefs].should == nil
     Capybara.current_session.driver.options[:profile].should_not be_a_kind_of String
     Capybara.current_session.driver.options[:browser].should_not be_a_kind_of String
   end
@@ -151,6 +152,23 @@ describe CapybaraSetup do
           Capybara.current_session.driver.options[:browser].should == :firefox
           Capybara.current_session.driver.options[:profile].should be_a_kind_of Selenium::WebDriver::Firefox::Profile
           Capybara.current_session.driver.options[:profile].instance_variable_get(:@additional_prefs)['network.http.sendRefererHeader'].should == 0
+        end
+        it_behaves_like "Selenium Driver Options Array"
+      end
+
+      context "with Selenium driver and additional firefox preferences" do
+        before do
+          ENV['BROWSER'] = 'firefox'
+          ENV['FIREFOX_PREFS'] = '{"javascript.enabled": false}'
+        end
+
+        it "should be initialized correctly" do 
+          Capybara.delete_session
+          CapybaraSetup.new.driver.should == :selenium
+          Capybara.current_session.driver.should be_a_kind_of Capybara::Selenium::Driver
+          Capybara.current_session.driver.options[:browser].should == :firefox
+          Capybara.current_session.driver.options[:profile].should be_a_kind_of Selenium::WebDriver::Firefox::Profile
+          Capybara.current_session.driver.options[:profile].instance_variable_get(:@additional_prefs)['javascript.enabled'].should == false
         end
         it_behaves_like "Selenium Driver Options Array"
       end

--- a/spec/frameworks_capybara_spec.rb
+++ b/spec/frameworks_capybara_spec.rb
@@ -89,6 +89,7 @@ describe CapybaraSetup do
           CapybaraSetup.new.driver.should == :selenium
           Capybara.current_session.driver.should be_a_kind_of Capybara::Selenium::Driver
           Capybara.current_session.driver.options[:browser].should == :firefox
+          Capybara.current_session.driver.options[:profile].instance_variable_get(:@native_events).should == true
         end
 
         it_behaves_like "Selenium Driver Options Array"


### PR DESCRIPTION
The first commit ensures that `create_profile` is always called even if no FIREFOX_PROFILE is specified. This means native_events is always enabled.

The second commit adds a FIREFOX_PREFS environment variable in which you specify a json string of additional preferences e.g. FIREFOX_PREFS='{"javascript.enabled": false}'
