### PR TITLE
Missing referer header

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,13 +1,15 @@
+Updated capybara-mechanize patch to send referer header.
+
 0.2.22
-Update Centos6 sandbox DNS to sandbox.bbc.co.uk
+Update Centos6 sandbox DNS to sandbox.bbc.co.uk.
 
 0.2.21
-Add support for Centos6 sandbox
-Update Gemfile.lock to latest gem versions
+Add support for Centos6 sandbox.
+Update Gemfile.lock to latest gem versions.
 
 0.2.20
-validate_online() now takes optional hash of parameters to pass to MarkupValidator
+validate_online() now takes optional hash of parameters to pass to MarkupValidator.
 Updated proxy handling to pick up port and to work without protocol or port. 
 
 0.2.19
-Present production release
+Present production release.

--- a/Gemfile
+++ b/Gemfile
@@ -4,4 +4,6 @@ platforms :jruby do
   gem "jruby-openssl"
 end
 
+gem "rspec-mocks"
+
 gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,3 +96,4 @@ DEPENDENCIES
   jruby-openssl
   rake
   rspec (>= 1.0.0)
+  rspec-mocks

--- a/lib/monkey-patches/capybara-mechanize-patches.rb
+++ b/lib/monkey-patches/capybara-mechanize-patches.rb
@@ -19,9 +19,9 @@ class Capybara::Mechanize::Browser
       args << headers unless headers.empty?
 
       if method == :get
-        @agent.send(method, url, attributes, referer, headers)
+        agent.send(method, url, attributes, referer, headers)
       else
-        @agent.send(method, url, *args)              
+        agent.send(method, url, *args)
       end
 
       @last_request_remote = true

--- a/lib/monkey-patches/capybara-mechanize-patches.rb
+++ b/lib/monkey-patches/capybara-mechanize-patches.rb
@@ -10,8 +10,7 @@ class Capybara::Mechanize::Browser
       @last_remote_uri = uri
       url = uri.to_s
 
-      referer = nil
-      referer = Capybara::page.current_url unless Capybara::page.current_url.empty?
+      referer = (!current_url.empty?) ? current_url : nil
 
       reset_cache!
       args = []

--- a/lib/monkey-patches/capybara-mechanize-patches.rb
+++ b/lib/monkey-patches/capybara-mechanize-patches.rb
@@ -10,7 +10,11 @@ class Capybara::Mechanize::Browser
       @last_remote_uri = uri
       url = uri.to_s
 
-      referer = (!current_url.empty?) ? current_url : nil
+      referer = nil
+      referer_candidate = current_url
+      unless referer_candidate.empty? or (referer_candidate.start_with?('https://') and url.start_with?('http://'))
+        referer = referer_candidate
+      end
 
       reset_cache!
       args = []

--- a/spec/capybara_mechanize_patches_spec.rb
+++ b/spec/capybara_mechanize_patches_spec.rb
@@ -1,0 +1,63 @@
+require 'spec_helper'
+require 'rspec/mocks/mock'
+require 'uri'
+
+describe Capybara::Mechanize::Browser do
+
+  RSpec::Mocks::setup(self)
+
+  it "should send referer for GET requests" do
+
+    agent = double()
+    agent.stub('get' => true)
+    agent.should_receive('get').with(
+      "http://example.bbc.co.uk/test",
+      {},
+      "http://example.bbc.co.uk/blah",
+      {}
+    )
+
+    driver = double("Capybara::Mechanize::Driver")
+    
+    browser = Capybara::Mechanize::Browser.new(driver)
+    browser.stub('current_url' => "http://example.bbc.co.uk/blah")
+    browser.stub('agent' => agent)
+
+    browser.process_remote_request(:get, 'http://example.bbc.co.uk/test', {}, {})    
+  end
+
+  it "shouldn't send referer if unknown" do
+
+    agent = double()
+    agent.stub('get' => true)
+    agent.should_receive('get').with(
+      "http://example.bbc.co.uk/test",
+      {},
+      nil,
+      {}
+    )
+
+    driver = double("Capybara::Mechanize::Driver")
+    
+    browser = Capybara::Mechanize::Browser.new(driver)
+    browser.stub('current_url' => "")
+    browser.stub('agent' => agent)
+
+    browser.process_remote_request(:get, 'http://example.bbc.co.uk/test', {}, {})    
+  end
+
+  it "should not change behaviour for POST requests" do
+
+    agent = double()
+    agent.stub('post' => true)
+    agent.should_receive('post').with("http://example.bbc.co.uk/test")
+
+    driver = double("Capybara::Mechanize::Driver")
+    
+    browser = Capybara::Mechanize::Browser.new(driver)
+    browser.stub('current_url' => "http://example.bbc.co.uk/blah")
+    browser.stub('agent' => agent)
+
+    browser.process_remote_request(:post, 'http://example.bbc.co.uk/test', {}, {})
+  end
+end

--- a/spec/capybara_mechanize_patches_spec.rb
+++ b/spec/capybara_mechanize_patches_spec.rb
@@ -6,26 +6,6 @@ describe Capybara::Mechanize::Browser do
 
   RSpec::Mocks::setup(self)
 
-  it "should send referer for GET requests" do
-
-    agent = double()
-    agent.stub('get' => true)
-    agent.should_receive('get').with(
-      "http://example.bbc.co.uk/test",
-      {},
-      "http://example.bbc.co.uk/blah",
-      {}
-    )
-
-    driver = double("Capybara::Mechanize::Driver")
-    
-    browser = Capybara::Mechanize::Browser.new(driver)
-    browser.stub('current_url' => "http://example.bbc.co.uk/blah")
-    browser.stub('agent' => agent)
-
-    browser.process_remote_request(:get, 'http://example.bbc.co.uk/test', {}, {})
-  end
-
   it "shouldn't send referer if unknown" do
 
     agent = double()

--- a/spec/capybara_mechanize_patches_spec.rb
+++ b/spec/capybara_mechanize_patches_spec.rb
@@ -23,7 +23,7 @@ describe Capybara::Mechanize::Browser do
     browser.stub('current_url' => "http://example.bbc.co.uk/blah")
     browser.stub('agent' => agent)
 
-    browser.process_remote_request(:get, 'http://example.bbc.co.uk/test', {}, {})    
+    browser.process_remote_request(:get, 'http://example.bbc.co.uk/test', {}, {})
   end
 
   it "shouldn't send referer if unknown" do
@@ -43,7 +43,7 @@ describe Capybara::Mechanize::Browser do
     browser.stub('current_url' => "")
     browser.stub('agent' => agent)
 
-    browser.process_remote_request(:get, 'http://example.bbc.co.uk/test', {}, {})    
+    browser.process_remote_request(:get, 'http://example.bbc.co.uk/test', {}, {})
   end
 
   it "should not change behaviour for POST requests" do
@@ -60,4 +60,85 @@ describe Capybara::Mechanize::Browser do
 
     browser.process_remote_request(:post, 'http://example.bbc.co.uk/test', {}, {})
   end
+
+  it "should not send referer for requests from HTTPs to HTTP" do
+
+    agent = double()
+    agent.stub('get' => true)
+    agent.should_receive('get').with(
+      "http://example.bbc.co.uk/test",
+      {},
+      nil,
+      {}
+    )
+
+    driver = double("Capybara::Mechanize::Driver")
+    
+    browser = Capybara::Mechanize::Browser.new(driver)
+    browser.stub('current_url' => "https://example.bbc.co.uk/blah")
+    browser.stub('agent' => agent)
+
+    browser.process_remote_request(:get, 'http://example.bbc.co.uk/test', {}, {})
+  end
+
+  it "should send referer for requests from HTTP to HTTPs" do
+
+    agent = double()
+    agent.stub('get' => true)
+    agent.should_receive('get').with(
+      "https://example.bbc.co.uk/test",
+      {},
+      "http://example.bbc.co.uk/blah",
+      {}
+    )
+
+    driver = double("Capybara::Mechanize::Driver")
+    
+    browser = Capybara::Mechanize::Browser.new(driver)
+    browser.stub('current_url' => "http://example.bbc.co.uk/blah")
+    browser.stub('agent' => agent)
+
+    browser.process_remote_request(:get, 'https://example.bbc.co.uk/test', {}, {})
+  end
+
+  it "should send referer for requests from HTTP to HTTP" do
+
+    agent = double()
+    agent.stub('get' => true)
+    agent.should_receive('get').with(
+      "http://example.bbc.co.uk/test",
+      {},
+      "http://example.bbc.co.uk/blah",
+      {}
+    )
+
+    driver = double("Capybara::Mechanize::Driver")
+    
+    browser = Capybara::Mechanize::Browser.new(driver)
+    browser.stub('current_url' => "http://example.bbc.co.uk/blah")
+    browser.stub('agent' => agent)
+
+    browser.process_remote_request(:get, 'http://example.bbc.co.uk/test', {}, {})
+  end
+
+  it "should send referer for requests from HTTPs to HTTPs" do
+    
+    agent = double()
+    agent.stub('get' => true)
+    agent.should_receive('get').with(
+      "https://example.bbc.co.uk/test",
+      {},
+      "https://example.bbc.co.uk/blah",
+      {}
+    )
+
+    driver = double("Capybara::Mechanize::Driver")
+    
+    browser = Capybara::Mechanize::Browser.new(driver)
+    browser.stub('current_url' => "https://example.bbc.co.uk/blah")
+    browser.stub('agent' => agent)
+
+    browser.process_remote_request(:get, 'https://example.bbc.co.uk/test', {}, {})
+  end
+
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,4 +13,5 @@ Cucumber::RbSupport::RbLanguage.new(Cucumber::Runtime.new) #Need to load Cucumbe
 
 require 'frameworks/capybara'
 require 'frameworks/cucumber'
+require 'monkey-patches/capybara-mechanize-patches'
 require 'unit_test_monkeypatches.rb'


### PR DESCRIPTION
Mechanize-capybara `nil`s the `Referer` from request when the request URI starts with 'http(s)://'.

This behaviour may have changed in the latest Mechanize, however we don't have time to upgrade at the moment. Instead we've updated the current patch.

This patch sends the header as expected and follows modern browser behaviour when moving from http to https URLs.
