### PR TITLE
2.3.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    frameworks-capybara (2.3.0)
+    frameworks-capybara (2.3.1)
       capybara
       capybara-mechanize
       cucumber

--- a/README.rdoc
+++ b/README.rdoc
@@ -43,7 +43,7 @@ The following environment variables can be set to configure your tests:
   CHROME_SWITCHES - pass in any allowed switches for the Selenium chrome driver (http://peter.sh/experiments/chromium-command-line-switches/) e.g. CHROME_SWITCHES="--user-agent=Mozilla/5.0 (PLAYSTATION 3; 3.55)"
   PROJECT_NAME - optional project name description which gets displayed in Cucumber html reports 
   TEAM_NAME - optional team name description which gets displayed in Cucumber html reports 
-  BROWSER_CLI_ARGS - optional additional arguments to pass to local browser processes
+  BROWSER_CLI_ARGS - optional additional arguments to pass to local browser processes (individual arguments should be separated with spaces)
 
 The following environment variables are specific to running tests against a BrowserStack remote grid:
 

--- a/lib/frameworks/capybara.rb
+++ b/lib/frameworks/capybara.rb
@@ -12,6 +12,7 @@ class CapybaraSetup
   def initialize
 
     http_proxy = ENV['HTTP_PROXY'] || ENV['http_proxy']
+    browser_cli_args = ENV['BROWSER_CLI_ARGS'].split(/\s+/).compact if ENV['BROWSER_CLI_ARGS']
 
     capybara_opts = {:environment => ENV['ENVIRONMENT'],
       :http_proxy => http_proxy,
@@ -21,7 +22,7 @@ class CapybaraSetup
       :url => ENV['REMOTE_URL'],
       :chrome_switches => ENV['CHROME_SWITCHES'],
       :firefox_prefs => ENV['FIREFOX_PREFS'],
-      :args => ENV['BROWSER_CLI_ARGS']
+      :args => browser_cli_args
     }
 
     selenium_remote_opts = {:os => ENV['PLATFORM'],

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,3 +1,3 @@
 module FrameworksCapybara
-  VERSION = '2.3.0'
+  VERSION = '2.3.1'
 end

--- a/spec/frameworks_capybara_spec.rb
+++ b/spec/frameworks_capybara_spec.rb
@@ -95,6 +95,51 @@ describe CapybaraSetup do
         it_behaves_like "Selenium Driver Options Array"
       end
 
+      context "with no command-line arguments supplied" do
+        before do
+          ENV['BROWSER'] = 'phantomjs'
+        end
+
+        it "should be initialized correctly" do
+          Capybara.delete_session
+          expect(CapybaraSetup.new.driver).to eq :selenium
+          expect(Capybara.current_session.driver.options[:args]).to be nil
+        end
+      end
+
+      context "with single command-line argument supplied" do
+        before do
+          ENV['BROWSER'] = 'phantomjs'
+          ENV['BROWSER_CLI_ARGS'] = '--ignore-ssl-errors=true'
+        end
+
+        it "should be initialized correctly" do
+          Capybara.delete_session
+          expect(CapybaraSetup.new.driver).to eq :selenium
+          args = Capybara.current_session.driver.options[:args]
+          expect(args).to be_instance_of Array
+          expect(args.size).to eq 1
+          expect(args[0]).to eq '--ignore-ssl-errors=true'
+        end
+      end
+
+      context "with multiple command-line arguments supplied" do
+        before do
+          ENV['BROWSER'] = 'phantomjs'
+          ENV['BROWSER_CLI_ARGS'] = '--ignore-ssl-errors=true --remote-debugger-port=9000'
+        end
+
+        it "should be initialized correctly" do
+          Capybara.delete_session
+          expect(CapybaraSetup.new.driver).to eq :selenium
+          args = Capybara.current_session.driver.options[:args]
+          expect(args).to be_instance_of Array
+          expect(args.size).to eq 2
+          expect(args[0]).to eq '--ignore-ssl-errors=true'
+          expect(args[1]).to eq '--remote-debugger-port=9000'
+        end
+      end
+
       context "with Selenium driver and default firefox profile (from profiles.ini)" do
         before do
           ENV['BROWSER'] = 'firefox'


### PR DESCRIPTION
Allow multiple arguments in the BROWSER_CLI_ARGS environment variable to be parsed correctly.
